### PR TITLE
Merge kaushikcfd's linalg dialect implementation

### DIFF
--- a/mlir/dialects/__init__.py
+++ b/mlir/dialects/__init__.py
@@ -1,5 +1,6 @@
 from .affine import affine
 from .standard import standard
 from .loop import loop
+from .linalg import linalg
 
-STANDARD_DIALECTS = [affine, standard, loop]
+STANDARD_DIALECTS = [affine, standard, loop, linalg]

--- a/mlir/dialects/linalg.py
+++ b/mlir/dialects/linalg.py
@@ -37,145 +37,145 @@ from mlir.dialect import Dialect, DialectOp, is_op
 
 class LinalgBatchMatmul(DialectOp):
     _syntax_ = [("linalg.batch_matmul"
-                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
-                 " outs( {c_id.ssa_use} : {c_type.type} )"),
+                 " ins( {a_id.ssa_id} , {b_id.ssa_id} : {a_type.type} , {b_type.type} )"
+                 " outs( {c_id.ssa_id} : {c_type.type} )"),
                 ("linalg.batch_matmul"
-                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
-                 " init( {init_id.ssa_use} : {init_type.type} ) -> {out_type.type}")]
+                 " ins( {a_id.ssa_id} , {b_id.ssa_id} : {a_type.type} , {b_type.type} )"
+                 " init( {init_id.ssa_id} : {init_type.type} ) -> {out_type.type}")]
 
 
 class LinalgConvW(DialectOp):
     _syntax_ = [("linalg.conv_1d"
-                 " ins( {in_id.ssa_use} , {filter_id.ssa_use} : {in_type.type} , {filter_type.type} )"
-                 " outs( {out_id.ssa_use} : {out_type.type} )")]
+                 " ins( {in_id.ssa_id} , {filter_id.ssa_id} : {in_type.type} , {filter_type.type} )"
+                 " outs( {out_id.ssa_id} : {out_type.type} )")]
 
 
 class LinalgConvHW(DialectOp):
     _syntax_ = [("linalg.conv_2d"
-                 " ins( {in_id.ssa_use} , {filter_id.ssa_use} : {in_type.type} , {filter_type.type} )"
-                 " outs( {out_id.ssa_use} : {out_type.type} )")]
+                 " ins( {in_id.ssa_id} , {filter_id.ssa_id} : {in_type.type} , {filter_type.type} )"
+                 " outs( {out_id.ssa_id} : {out_type.type} )")]
 
 
 class LinalgConvDHW(DialectOp):
     _syntax_ = [("linalg.conv_3d"
-                 " ins( {in_id.ssa_use} , {filter_id.ssa_use} : {in_type.type} , {filter_type.type} )"
-                 " outs( {out_id.ssa_use} : {out_type.type} )")]
+                 " ins( {in_id.ssa_id} , {filter_id.ssa_id} : {in_type.type} , {filter_type.type} )"
+                 " outs( {out_id.ssa_id} : {out_type.type} )")]
 
 
 class LinalgConv(DialectOp):
-    _syntax_ = [("linalg.conv( {in_id.ssa_use} , {filter_id.ssa_use} , {out_id.ssa_use} ) "
+    _syntax_ = [("linalg.conv( {in_id.ssa_id} , {filter_id.ssa_id} , {out_id.ssa_id} ) "
                 "{attr.attribute_value} : {in_type.type} , {filter_type.type} , {out_type.type}"),
-                ("linalg.conv( {in_id.ssa_use} , {filter_id.ssa_use} , {out_id.ssa_use} ) "
+                ("linalg.conv( {in_id.ssa_id} , {filter_id.ssa_id} , {out_id.ssa_id} ) "
                 " : {in_type.type} , {filter_type.type} , {out_type.type}")]
 
 
 class LinalgCopy(DialectOp):
-    _syntax_ = [("linalg.copy( {a_id.ssa_use} , {b_id.ssa_use} ) "
+    _syntax_ = [("linalg.copy( {a_id.ssa_id} , {b_id.ssa_id} ) "
                 "{attr.attribute_value} : {a_type.type} , {b_type.type}"),
-                ("linalg.copy( {a_id.ssa_use} , {b_id.ssa_use} ) "
+                ("linalg.copy( {a_id.ssa_id} , {b_id.ssa_id} ) "
                 " : {a_type.type} , {b_type.type}")]
 
 
 class LinalgDot(DialectOp):
     _syntax_ = [("linalg.dot"
-                 " ins( {in_a_id.ssa_use} , {in_b_id.ssa_use} : {in_a_type.type} , {in_b_type.type} )"
-                 " outs( {out_id.ssa_use} : {out_type.type} )")]
+                 " ins( {in_a_id.ssa_id} , {in_b_id.ssa_id} : {in_a_type.type} , {in_b_type.type} )"
+                 " outs( {out_id.ssa_id} : {out_type.type} )")]
 
 
 class LinalgFill(DialectOp):
-    _syntax_ = [("linalg.fill( {output_id.ssa_use} , {value_id.ssa_use} ) "
+    _syntax_ = [("linalg.fill( {output_id.ssa_id} , {value_id.ssa_id} ) "
                 "{attr.attribute_value} : {output_type.type} , {value_type.type}"),
-                ("linalg.fill( {output_id.ssa_use} , {value_id.ssa_use} ) "
+                ("linalg.fill( {output_id.ssa_id} , {value_id.ssa_id} ) "
                 " : {output_type.type} , {value_type.type}")]
 
 
 class LinalgGeneric(DialectOp):
     _syntax_ = [("linalg.generic {attr.attribute_value} "
-                 " ins( {inargs.ssa_use_list} : {in_types.type_list_no_parens} )"
-                 " outs( {outargs.ssa_use_list} : {out_types.type_list_no_parens} )"
+                 " ins( {inargs.ssa_id_list} : {in_types.type_list_no_parens} )"
+                 " outs( {outargs.ssa_id_list} : {out_types.type_list_no_parens} )"
                  " {body.region}"),
                 ("linalg.generic {attr.attribute_value} "
-                 " ins( {inargs.ssa_use_list} : {in_types.type_list_no_parens} )"
-                 " init( {init_args.ssa_use_list} : {init_types.type_list_no_parens} )"
+                 " ins( {inargs.ssa_id_list} : {in_types.type_list_no_parens} )"
+                 " init( {init_args.ssa_id_list} : {init_types.type_list_no_parens} )"
                  " {body.region} -> {out_type.type}")]
 
 
 class LinalgIndexedGeneric(DialectOp):
     _syntax_ = [("linalg.indexed_generic {attr.attribute_value} "
-                 " ins( {inargs.ssa_use_list} : {in_types.type_list_no_parens} )"
-                 " outs( {outargs.ssa_use_list} : {out_types.type_list_no_parens} )"
+                 " ins( {inargs.ssa_id_list} : {in_types.type_list_no_parens} )"
+                 " outs( {outargs.ssa_id_list} : {out_types.type_list_no_parens} )"
                  " {body.region}"),
                 ("linalg.indexed_generic {attr.attribute_value} "
-                 " ins( {inargs.ssa_use_list} : {in_types.type_list_no_parens} )"
-                 " init( {init_args.ssa_use_list} : {init_types.type_list_no_parens} )"
+                 " ins( {inargs.ssa_id_list} : {in_types.type_list_no_parens} )"
+                 " init( {init_args.ssa_id_list} : {init_types.type_list_no_parens} )"
                  " {body.region} -> {out_type.type}")]
 
 
 class LinalgRange(DialectOp):
-    _syntax_ = [("linalg.range {min_id.ssa_use} : {max_id.ssa_use} : {step_id.ssa_use}"
+    _syntax_ = [("linalg.range {min_id.ssa_id} : {max_id.ssa_id} : {step_id.ssa_id}"
                  " {attr.attribute_value} : {out_type.type}"),
-                ("linalg.range {min_id.ssa_use} : {max_id.ssa_use} : {step_id.ssa_use}"
+                ("linalg.range {min_id.ssa_id} : {max_id.ssa_id} : {step_id.ssa_id}"
                  " : {out_type.type}")]
 
 
 class LinalgReshape(DialectOp):
-    _syntax_ = [("linalg.reshape {src_id.ssa_use}"
+    _syntax_ = [("linalg.reshape {src_id.ssa_id}"
                  " [ {reassociation.affine_map_list} ] "
                  " {attr.attribute_value} "
                  " : {src_type.memref_type} into {result_type.memref_type}"),
-                ("linalg.reshape {src_id.ssa_use}"
+                ("linalg.reshape {src_id.ssa_id}"
                  " [ ] "
                  " {attr.attribute_value} "
                  " : {src_type.memref_type} into {result_type.memref_type}"),
-                ("linalg.reshape {src_id.ssa_use}"
+                ("linalg.reshape {src_id.ssa_id}"
                  " [ {reassociation.affine_map_list} ] "
                  " : {src_type.memref_type} into {result_type.memref_type}"),
-                ("linalg.reshape {src_id.ssa_use}"
+                ("linalg.reshape {src_id.ssa_id}"
                  " [ ] "
                  " : {src_type.memref_type} into {result_type.memref_type}")]
 
 
 class LinalgSlice(DialectOp):
-    _syntax_ = ("linalg.slice {view_id.ssa_use} [ {indexing_ids.ssa_use_list} ]"
+    _syntax_ = ("linalg.slice {view_id.ssa_id} [ {indexing_ids.ssa_id_list} ]"
                 " : {view_type.type} , {indexing_types.type_list_no_parens} "
                 " , {result_type.type}")
 
 
 class TensorReshape(DialectOp):
-    _syntax_ = [("linalg.tensor_reshape {src_id.ssa_use}"
+    _syntax_ = [("linalg.tensor_reshape {src_id.ssa_id}"
                  " [ {reassociation.affine_map_list} ] "
                  " {attr.attribute_value} "
                  " : {src_type.tensor_type} into {result_type.tensor_type}"),
-                ("linalg.tensor_reshape {src_id.ssa_use}"
+                ("linalg.tensor_reshape {src_id.ssa_id}"
                  " [ ] "
                  " {attr.attribute_value} "
                  " : {src_type.tensor_type} into {result_type.tensor_type}"),
-                ("linalg.tensor_reshape {src_id.ssa_use}"
+                ("linalg.tensor_reshape {src_id.ssa_id}"
                  " [ {reassociation.affine_map_list} ] "
                  " : {src_type.tensor_type} into {result_type.tensor_type}"),
-                ("linalg.tensor_reshape {src_id.ssa_use}"
+                ("linalg.tensor_reshape {src_id.ssa_id}"
                  " [ ] "
                  " : {src_type.tensor_type} into {result_type.tensor_type}")]
 
 
 class LinalgYield(DialectOp):
-    _syntax_ = ("linalg.yield {operand_ids.ssa_use_list}"
+    _syntax_ = ("linalg.yield {operand_ids.ssa_id_list}"
                 " : {operand_types.type_list_no_parens}")
 
 
 class LinalgMatmul(DialectOp):
     _syntax_ = [("linalg.matmul"
-                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
-                 " outs( {c_id.ssa_use} : {c_type.type} )"),
+                 " ins( {a_id.ssa_id} , {b_id.ssa_id} : {a_type.type} , {b_type.type} )"
+                 " outs( {c_id.ssa_id} : {c_type.type} )"),
                 ("linalg.matmul"
-                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
-                 " init( {init_id.ssa_use} : {init_type.type} )  -> {out_type.type}")]
+                 " ins( {a_id.ssa_id} , {b_id.ssa_id} : {a_type.type} , {b_type.type} )"
+                 " init( {init_id.ssa_id} : {init_type.type} )  -> {out_type.type}")]
 
 
 class LinalgMatvec(DialectOp):
     _syntax_ = [("linalg.matvec"
-                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
-                 " outs( {c_id.ssa_use} : {c_type.type} )")]
+                 " ins( {a_id.ssa_id} , {b_id.ssa_id} : {a_type.type} , {b_type.type} )"
+                 " outs( {c_id.ssa_id} : {c_type.type} )")]
 
 
 # Inspect current module to get all classes defined above

--- a/mlir/dialects/linalg.py
+++ b/mlir/dialects/linalg.py
@@ -1,0 +1,183 @@
+""" Implementation of the Linalg dialect. """
+
+__copyright__ = "Copyright (C) 2020 Kaushik Kulkarni"
+
+__license__ = """
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+
+import inspect
+import sys
+from mlir.dialect import Dialect, DialectOp, is_op
+
+
+class LinalgBatchMatmul(DialectOp):
+    _syntax_ = [("linalg.batch_matmul"
+                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
+                 " outs( {c_id.ssa_use} : {c_type.type} )"),
+                ("linalg.batch_matmul"
+                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
+                 " init( {init_id.ssa_use} : {init_type.type} ) -> {out_type.type}")]
+
+
+class LinalgConvW(DialectOp):
+    _syntax_ = [("linalg.conv_1d"
+                 " ins( {in_id.ssa_use} , {filter_id.ssa_use} : {in_type.type} , {filter_type.type} )"
+                 " outs( {out_id.ssa_use} : {out_type.type} )")]
+
+
+class LinalgConvHW(DialectOp):
+    _syntax_ = [("linalg.conv_2d"
+                 " ins( {in_id.ssa_use} , {filter_id.ssa_use} : {in_type.type} , {filter_type.type} )"
+                 " outs( {out_id.ssa_use} : {out_type.type} )")]
+
+
+class LinalgConvDHW(DialectOp):
+    _syntax_ = [("linalg.conv_3d"
+                 " ins( {in_id.ssa_use} , {filter_id.ssa_use} : {in_type.type} , {filter_type.type} )"
+                 " outs( {out_id.ssa_use} : {out_type.type} )")]
+
+
+class LinalgConv(DialectOp):
+    _syntax_ = [("linalg.conv( {in_id.ssa_use} , {filter_id.ssa_use} , {out_id.ssa_use} ) "
+                "{attr.attribute_value} : {in_type.type} , {filter_type.type} , {out_type.type}"),
+                ("linalg.conv( {in_id.ssa_use} , {filter_id.ssa_use} , {out_id.ssa_use} ) "
+                " : {in_type.type} , {filter_type.type} , {out_type.type}")]
+
+
+class LinalgCopy(DialectOp):
+    _syntax_ = [("linalg.copy( {a_id.ssa_use} , {b_id.ssa_use} ) "
+                "{attr.attribute_value} : {a_type.type} , {b_type.type}"),
+                ("linalg.copy( {a_id.ssa_use} , {b_id.ssa_use} ) "
+                " : {a_type.type} , {b_type.type}")]
+
+
+class LinalgDot(DialectOp):
+    _syntax_ = [("linalg.dot"
+                 " ins( {in_a_id.ssa_use} , {in_b_id.ssa_use} : {in_a_type.type} , {in_b_type.type} )"
+                 " outs( {out_id.ssa_use} : {out_type.type} )")]
+
+
+class LinalgFill(DialectOp):
+    _syntax_ = [("linalg.fill( {output_id.ssa_use} , {value_id.ssa_use} ) "
+                "{attr.attribute_value} : {output_type.type} , {value_type.type}"),
+                ("linalg.fill( {output_id.ssa_use} , {value_id.ssa_use} ) "
+                " : {output_type.type} , {value_type.type}")]
+
+
+class LinalgGeneric(DialectOp):
+    _syntax_ = [("linalg.generic {attr.attribute_value} "
+                 " ins( {inargs.ssa_use_list} : {in_types.type_list_no_parens} )"
+                 " outs( {outargs.ssa_use_list} : {out_types.type_list_no_parens} )"
+                 " {body.region}"),
+                ("linalg.generic {attr.attribute_value} "
+                 " ins( {inargs.ssa_use_list} : {in_types.type_list_no_parens} )"
+                 " init( {init_args.ssa_use_list} : {init_types.type_list_no_parens} )"
+                 " {body.region} -> {out_type.type}")]
+
+
+class LinalgIndexedGeneric(DialectOp):
+    _syntax_ = [("linalg.indexed_generic {attr.attribute_value} "
+                 " ins( {inargs.ssa_use_list} : {in_types.type_list_no_parens} )"
+                 " outs( {outargs.ssa_use_list} : {out_types.type_list_no_parens} )"
+                 " {body.region}"),
+                ("linalg.indexed_generic {attr.attribute_value} "
+                 " ins( {inargs.ssa_use_list} : {in_types.type_list_no_parens} )"
+                 " init( {init_args.ssa_use_list} : {init_types.type_list_no_parens} )"
+                 " {body.region} -> {out_type.type}")]
+
+
+class LinalgRange(DialectOp):
+    _syntax_ = [("linalg.range {min_id.ssa_use} : {max_id.ssa_use} : {step_id.ssa_use}"
+                 " {attr.attribute_value} : {out_type.type}"),
+                ("linalg.range {min_id.ssa_use} : {max_id.ssa_use} : {step_id.ssa_use}"
+                 " : {out_type.type}")]
+
+
+class LinalgReshape(DialectOp):
+    _syntax_ = [("linalg.reshape {src_id.ssa_use}"
+                 " [ {reassociation.affine_map_list} ] "
+                 " {attr.attribute_value} "
+                 " : {src_type.memref_type} into {result_type.memref_type}"),
+                ("linalg.reshape {src_id.ssa_use}"
+                 " [ ] "
+                 " {attr.attribute_value} "
+                 " : {src_type.memref_type} into {result_type.memref_type}"),
+                ("linalg.reshape {src_id.ssa_use}"
+                 " [ {reassociation.affine_map_list} ] "
+                 " : {src_type.memref_type} into {result_type.memref_type}"),
+                ("linalg.reshape {src_id.ssa_use}"
+                 " [ ] "
+                 " : {src_type.memref_type} into {result_type.memref_type}")]
+
+
+class LinalgSlice(DialectOp):
+    _syntax_ = ("linalg.slice {view_id.ssa_use} [ {indexing_ids.ssa_use_list} ]"
+                " : {view_type.type} , {indexing_types.type_list_no_parens} "
+                " , {result_type.type}")
+
+
+class TensorReshape(DialectOp):
+    _syntax_ = [("linalg.tensor_reshape {src_id.ssa_use}"
+                 " [ {reassociation.affine_map_list} ] "
+                 " {attr.attribute_value} "
+                 " : {src_type.tensor_type} into {result_type.tensor_type}"),
+                ("linalg.tensor_reshape {src_id.ssa_use}"
+                 " [ ] "
+                 " {attr.attribute_value} "
+                 " : {src_type.tensor_type} into {result_type.tensor_type}"),
+                ("linalg.tensor_reshape {src_id.ssa_use}"
+                 " [ {reassociation.affine_map_list} ] "
+                 " : {src_type.tensor_type} into {result_type.tensor_type}"),
+                ("linalg.tensor_reshape {src_id.ssa_use}"
+                 " [ ] "
+                 " : {src_type.tensor_type} into {result_type.tensor_type}")]
+
+
+class LinalgYield(DialectOp):
+    _syntax_ = ("linalg.yield {operand_ids.ssa_use_list}"
+                " : {operand_types.type_list_no_parens}")
+
+
+class LinalgMatmul(DialectOp):
+    _syntax_ = [("linalg.matmul"
+                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
+                 " outs( {c_id.ssa_use} : {c_type.type} )"),
+                ("linalg.matmul"
+                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
+                 " init( {init_id.ssa_use} : {init_type.type} )  -> {out_type.type}")]
+
+
+class LinalgMatvec(DialectOp):
+    _syntax_ = [("linalg.matvec"
+                 " ins( {a_id.ssa_use} , {b_id.ssa_use} : {a_type.type} , {b_type.type} )"
+                 " outs( {c_id.ssa_use} : {c_type.type} )")]
+
+
+# Inspect current module to get all classes defined above
+linalg = Dialect("linalg", ops=[m[1] for m in inspect.getmembers(
+    sys.modules[__name__], lambda obj: is_op(obj, __name__))])

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,0 +1,161 @@
+import sys
+import mlir
+
+# All source strings have been taken from MLIR's codebase.
+# See llvm-project/mlir/test/Dialect/Linalg
+
+
+def assert_roundtrip_equivalence(source):
+    assert source == mlir.parse_string(source).dump()
+
+
+def test_batch_matmul():
+    assert_roundtrip_equivalence("""module {
+  func @named_ops(%a3: memref<?x?x?xf32>, %b3: memref<?x?x?xf32>, %c3: memref<?x?x?xf32>, %ta3: tensor<?x?x?xf32>, %tb3: tensor<?x?x?xf32>, %tc3: tensor<?x?x?xf32>) -> (tensor<?x?x?xf32>, tensor<?x?x?xf32>) {
+    linalg.batch_matmul ins( %a3 , %b3 : memref<?x?x?xf32> , memref<?x?x?xf32> ) outs( %c3 : memref<?x?x?xf32> )
+    linalg.batch_matmul ins( %ta3 , %tb3 : tensor<?x?x?xf32> , tensor<?x?x?xf32> ) outs( %c3 : memref<?x?x?xf32> )
+    %res1 = linalg.batch_matmul ins( %ta3 , %tb3 : tensor<?x?x?xf32> , tensor<?x?x?xf32> ) init( %tc3 : tensor<?x?x?xf32> ) -> tensor<?x?x?xf32>
+    %res2 = linalg.batch_matmul ins( %ta3 , %b3 : tensor<?x?x?xf32> , memref<?x?x?xf32> ) init( %tc3 : tensor<?x?x?xf32> ) -> tensor<?x?x?xf32>
+    return %res1, %res2 : tensor<?x?x?xf32>, tensor<?x?x?xf32>
+  }
+}""")
+
+
+def test_conv():
+    assert_roundtrip_equivalence("""module {
+  func @conv1d_no_symbols(%in: memref<?xf32>, %filter: memref<?xf32>, %out: memref<?xf32>) {
+    linalg.conv_1d ins( %in , %filter : memref<?xf32> , memref<?xf32> ) outs( %out : memref<?xf32> )
+    return
+  }
+  func @conv2d_no_symbols(%in: memref<?x?xf32>, %filter: memref<?x?xf32>, %out: memref<?x?xf32>) {
+    linalg.conv_2d ins( %in , %filter : memref<?x?xf32> , memref<?x?xf32> ) outs( %out : memref<?x?xf32> )
+    return
+  }
+  func @conv3d_no_symbols(%in: memref<?x?x?xf32>, %filter: memref<?x?x?xf32>, %out: memref<?x?x?xf32>) {
+    linalg.conv_3d ins( %in , %filter : memref<?x?x?xf32> , memref<?x?x?xf32> ) outs( %out : memref<?x?x?xf32> )
+    return
+  }
+}""")
+
+
+def test_copy():
+    assert_roundtrip_equivalence("""module {
+  func @copy_view(%arg0: memref<?xf32, offset: ?, strides: [1]>, %arg1: memref<?xf32, offset: ?, strides: [1]>) {
+    linalg.copy( %arg0 , %arg1 )  : memref<?xf32, offset: ?, strides: [1]> , memref<?xf32, offset: ?, strides: [1]>
+    return
+  }
+  func @copy_view3(%arg0: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>, %arg1: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>) {
+    linalg.copy( %arg0 , %arg1 ) {inputPermutation = affine_map<(i, j, k) -> (i, k, j)>, outputPermutation = affine_map<(i, j, k) -> (k, j, i)>} : memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]> , memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>
+    return
+  }
+}""")
+
+
+def test_dot():
+    assert_roundtrip_equivalence("""module {
+  func @dot(%arg0: memref<?xi8>, %M: index) {
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %1 = view %arg0 [ %c0 ] [ %M ] : memref<?xi8> to memref<?xf32>
+    %2 = view %arg0 [ %c0 ] [ %M ] : memref<?xi8> to memref<?xf32>
+    %3 = view %arg0 [ %c0 ] [  ] : memref<?xi8> to memref<f32>
+    linalg.dot ins( %1 , %2 : memref<?xf32> , memref<?xf32> ) outs( %3 : memref<f32> )
+    return
+  }
+}""")
+
+
+def test_fill():
+    assert_roundtrip_equivalence("""module {
+  func @fill_view(%arg0: memref<?xf32, offset: ?, strides: [1]>, %arg1: f32) {
+    linalg.fill( %arg0 , %arg1 )  : memref<?xf32, offset: ?, strides: [1]> , f32
+    return
+  }
+}""")
+
+
+def test_generic():
+    assert_roundtrip_equivalence("""module {
+  func @example(%A: memref<?x?xf64>, %B: memref<?x?xf64>, %C: memref<?x?xf64>) {
+    linalg.generic {indexing_maps = [affine_map<(i, j) -> (i, j)>, affine_map<(i, j) -> (i, j)>, affine_map<(i, j) -> (i, j)>], iterator_types = ["parallel", "parallel"]}  ins( %A, %B : memref<?x?xf64>, memref<?x?xf64> ) outs( %C : memref<?x?xf64> ) {
+      ^bb0 (%a: f64, %b: f64, %c: f64):
+        %c0 = constant 3.14 : f64
+        %d = addf %a , %b : f64
+        linalg.yield %d : f64
+    }
+    return
+  }
+}""")
+
+
+def test_indexed_generic():
+    assert_roundtrip_equivalence("""module {
+  func @indexed_generic_region(%arg0: memref<?x?xf32, offset: ?, strides: [?, 1]>, %arg1: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>, %arg2: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>) {
+    linalg.indexed_generic {args_in = 1, args_out = 2, iterator_types = ["parallel", "parallel", "parallel"], indexing_maps = [affine_map<(i, j, k) -> (i, j)>, affine_map<(i, j, k) -> (i, j, k)>, affine_map<(i, j, k) -> (i, k, j)>], library_call = "some_external_function_name_2", doc = "B(i,j,k), C(i,k,j) = foo(A(i, j) * B(i,j,k), i * j * k + C(i,k,j))"}  ins( %arg0 : memref<?x?xf32, offset: ?, strides: [?, 1]> ) outs( %arg1, %arg2 : memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>, memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]> ) {
+      ^bb0 (%i: index, %j: index, %k: index, %a: f32, %b: f32, %c: f32):
+        %result_1 = mulf %a , %b : f32
+        %ij = addi %i , %j : index
+        %ijk = addi %ij , %k : index
+        %ijk_int = index_cast %ijk : index to i32
+        %ijk_float = sitofp %ijk_int : (i32) -> f32
+        %result_2 = addf %c , %ijk_float : f32
+        linalg.yield %result_1, %result_2 : f32, f32
+    }
+    return
+  }
+}""")
+
+
+def test_view():
+    assert_roundtrip_equivalence("""module {
+  func @views(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
+    %c0 = constant 0 : index
+    %0 = muli %arg0 , %arg0 : index
+    %1 = alloc (%0) : memref<?xi8>
+    %2 = linalg.range %arg0 : %arg1 : %arg 2 : !linalg.range
+    %3 = view %1 [ %c0 ] [ %arg0, %arg0 ] : memref<?xi8> to memref<?x?xf32>
+    %4 = linalg.slice %3 [ %2, %2 ] : memref<?x?xf32> , !linalg.range, !linalg.range  , memref<?x?xf32>
+    %5 = linalg.slice %3 [ %2, %arg2 ] : memref<?x?xf32> , !linalg.range, index  , memref<?xf32, offset: ?, strides: [1]>
+    %6 = linalg.slice %3 [ %arg2, %2 ] : memref<?x?xf32> , index, !linalg.range  , memref<?xf32, offset: ?, strides: [1]>
+    %7 = linalg.slice %3 [ %arg2, %arg3 ] : memref<?x?xf32> , index, index  , memref<f32>
+    %8 = view %1 [ %c0 ] [ %arg0, %arg0 ] : memref<?xi8> to memref<?x?xvector<4x4xf32>>
+    dealloc %1 : memref<?xi8>
+    return
+  }
+}""")
+
+
+def test_matmul():
+    assert_roundtrip_equivalence("""module {
+  func @matmul(%arg0: memref<?xi8>, %M: index, %N: index, %K: index) {
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %A = view %arg0 [ %c0 ] [ %M, %K ] : memref<?xi8> to memref<?x?xf32>
+    %B = view %arg0 [ %c0 ] [ %K, %N ] : memref<?xi8> to memref<?x?xf32>
+    %C = view %arg0 [ %c0 ] [ %M, %N ] : memref<?xi8> to memref<?x?xf32>
+    linalg.matmul ins( %A , %B : memref<?x?xf32> , memref<?x?xf32> ) outs( %C : memref<?x?xf32> )
+    return
+  }
+}""")
+
+
+def test_matvec():
+    assert_roundtrip_equivalence("""module {
+  func @matvec(%arg0: memref<?xi8>, %M: index, %N: index) {
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %2 = view %arg0 [ %c0 ] [ %M, %N ] : memref<?xi8> to memref<?x?xf32>
+    %3 = view %arg0 [ %c0 ] [ %M ] : memref<?xi8> to memref<?xf32>
+    %4 = view %arg0 [ %c0 ] [ %N ] : memref<?xi8> to memref<?xf32>
+    linalg.matvec ins( %2 , %3 : memref<?x?xf32> , memref<?xf32> ) outs( %4 : memref<?xf32> )
+    return
+  }
+}""")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])


### PR DESCRIPTION
This PR merges in the changes from kaushikcfd's implementation of the linalg dialect. 

NB: 
  - One example that raises an exception is this one:
 ```
>>> mlir.parse_string('''
#trait_add = {
  indexing_maps = [
    affine_map<(i,j) -> (i,j)>,  // A
    affine_map<(i,j) -> (i,j)>,  // B
    affine_map<(i,j) -> (i,j)>   // X (out)
  ],
  //sparse = [
  //  [ "D", "D" ],  // A
  //  [ "D", "D" ],  // B
  //  [ "D", "D" ]   // X
  //],
  iterator_types = ["parallel", "parallel"],
  doc = "X(i,j) = A(i,j) OP B(i,j)"
}
func @add_func(%arga: tensor<32x16xf32>, %argb: tensor<32x16xf32>) -> tensor<32x16xf32> {
  %0 = linalg.generic #trait_add
     ins(%arga, %argb: tensor<32x16xf32>, tensor<32x16xf32>)
    outs(%arga: tensor<32x16xf32>) {
      ^bb(%a: f32, %b: f32, %s: f32):
        %0 = addf %a, %b  : f32
        linalg.yield %0 : f32
  } -> tensor<32x16xf32>
  return %0 : tensor<32x16xf32>
}
''')
```
  - It works if we remove the `-> tensor<32x16xf32>` on the `linalg.generic` op.
```
>>> mlir.parse_string('''
#trait_add = {
  indexing_maps = [
    affine_map<(i,j) -> (i,j)>,  // A
    affine_map<(i,j) -> (i,j)>,  // B
    affine_map<(i,j) -> (i,j)>   // X (out)
  ],
  //sparse = [
  //  [ "D", "D" ],  // A
  //  [ "D", "D" ],  // B
  //  [ "D", "D" ]   // X
  //],
  iterator_types = ["parallel", "parallel"],
  doc = "X(i,j) = A(i,j) OP B(i,j)"
}
func @add_func(%arga: tensor<32x16xf32>, %argb: tensor<32x16xf32>) -> tensor<32x16xf32> {
  %0 = linalg.generic #trait_add
     ins(%arga, %argb: tensor<32x16xf32>, tensor<32x16xf32>)
    outs(%arga: tensor<32x16xf32>) {
      ^bb(%a: f32, %b: f32, %s: f32):
        %0 = addf %a, %b  : f32
        linalg.yield %0 : f32
  } // -> tensor<32x16xf32>
  return %0 : tensor<32x16xf32>
}

''')
Module(name=None, attributes=None, body=[AttrAliasDef(name=AttrAlias(value=trait_add), value=DictionaryAttr(value=[AttributeEntry(name=indexing_maps, value=ArrayAttr(value=[IntSetAttr(value=AffineMap(dims_and_symbols=DimAndSymbolList(dims=['i', 'j'], symbols=[]), map=MultiDimAffineExpr(dims=['i', 'j']))), IntSetAttr(value=AffineMap(dims_and_symbols=DimAndSymbolList(dims=['i', 'j'], symbols=[]), map=MultiDimAffineExpr(dims=['i', 'j']))), IntSetAttr(value=AffineMap(dims_and_symbols=DimAndSymbolList(dims=['i', 'j'], symbols=[]), map=MultiDimAffineExpr(dims=['i', 'j'])))])), AttributeEntry(name=iterator_types, value=ArrayAttr(value=[StringAttr(value="parallel", type=None), StringAttr(value="parallel", type=None)])), AttributeEntry(name=doc, value=StringAttr(value="X(i,j) = A(i,j) OP B(i,j)", type=None))])), Function(name=SymbolRefId(value=add_func), args=[NamedArgument(name=SsaId(value=arga, index=None), type=RankedTensorType(dimensions=[Dimension(value=32), Dimension(value=16)], element_type=FloatType(type=FloatTypeEnum.f32)), attributes=None), NamedArgument(name=SsaId(value=argb, index=None), type=RankedTensorType(dimensions=[Dimension(value=32), Dimension(value=16)], element_type=FloatType(type=FloatTypeEnum.f32)), attributes=None)], result_types=RankedTensorType(dimensions=[Dimension(value=32), Dimension(value=16)], element_type=FloatType(type=FloatTypeEnum.f32)), attributes=None, body=Region(body=[Block(label=None, body=[Operation(result_list=[OpResult(value=SsaId(value=0, index=None), count=None)], op=LinalgGeneric(out_type=None, init_args=None, inargs=[SsaId(value=arga, index=None), SsaId(value=argb, index=None)], attr=AttrAlias(value=trait_add), in_types=[RankedTensorType(dimensions=[Dimension(value=32), Dimension(value=16)], element_type=FloatType(type=FloatTypeEnum.f32)), RankedTensorType(dimensions=[Dimension(value=32), Dimension(value=16)], element_type=FloatType(type=FloatTypeEnum.f32))], out_types=[RankedTensorType(dimensions=[Dimension(value=32), Dimension(value=16)], element_type=FloatType(type=FloatTypeEnum.f32))], outargs=[SsaId(value=arga, index=None)], init_types=None, body=Region(body=[Block(label=BlockLabel(name=BlockId(value=bb), arg_ids=(SsaId(value=a, index=None), SsaId(value=b, index=None), SsaId(value=s, index=None)), arg_types=(FloatType(type=FloatTypeEnum.f32), FloatType(type=FloatTypeEnum.f32), FloatType(type=FloatTypeEnum.f32))), body=[Operation(result_list=[OpResult(value=SsaId(value=0, index=None), count=None)], op=AddfOperation(operand_b=SsaId(value=b, index=None), operand_a=SsaId(value=a, index=None), type=FloatType(type=FloatTypeEnum.f32)), location=None), Operation(result_list=[], op=LinalgYield(operand_ids=[SsaId(value=0, index=None)], operand_types=[FloatType(type=FloatTypeEnum.f32)]), location=None)])])), location=None), Operation(result_list=[], op=ReturnOperation(values=[SsaId(value=0, index=None)], types=[RankedTensorType(dimensions=[Dimension(value=32), Dimension(value=16)], element_type=FloatType(type=FloatTypeEnum.f32))]), location=None)])]), location=None)], location=None)
>>> 
```