### PR TITLE
Capture function visibility: public, private, nested

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -133,4 +133,4 @@ jobs:
           ls -la .
           UPLOAD=`ls .`
           echo "Uploading $UPLOAD with label=${{ env.AC_LABEL }}"
-          anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u metagraph -l ${{ env.AC_LABEL }} --no-progress --force --register $UPLOAD
+          anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u metagraph -l ${{ env.AC_LABEL }} --no-progress --force --no-register $UPLOAD

--- a/continuous_integration/conda/meta.yaml
+++ b/continuous_integration/conda/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pymlir
-  version: 0.3
+  version: 0.3.1
 
 source:
   path: ../..

--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -670,30 +670,37 @@ class Module(Node):
 
 class Function(Node):
     _fields_ = [
-        'name', 'args', 'result_types', 'attributes', 'body', 'location'
+        'name', 'args', 'result_types', 'attributes', 'body', 'location', 'visibility',
     ]
 
     def __init__(self, node: Token = None, **fields):
-        signature = node[0].children
-        # Parse signature
         index = 0
-        self.name = signature[index]
-        index += 1
-        if len(signature) > index and signature[index].data == 'argument_list':
-            self.args = signature[index].children
+        # Parse function visibility
+        if node[index].data == "function_visibility":
+            self.visibility = node[index].children[0].value
             index += 1
         else:
+            self.visibility = "public"
+        # Parse signature
+        signature = node[index].children
+        sigindex = 0
+        self.name = signature[sigindex]
+        sigindex += 1
+        if len(signature) > sigindex and signature[sigindex].data == 'argument_list':
+            self.args = signature[sigindex].children
+            sigindex += 1
+        else:
             self.args = []
-        if (len(signature) > index
-                and signature[index].data == 'function_result_list'):
+        if (len(signature) > sigindex
+                and signature[sigindex].data == 'function_result_list'):
             # first child contains all the result types
-            self.result_types = signature[index].children[0]
-            index += 1
+            self.result_types = signature[sigindex].children[0]
+            sigindex += 1
         else:
             self.result_types = []
 
         # Parse rest of function
-        index = 1
+        index += 1
         if len(node) > index and isinstance(node[index], AttributeDict):
             self.attributes = node[index]
             index += 1

--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -184,6 +184,12 @@ region : "{" block* "}"
 // ----------------------------------------------------------------------
 // Modules and functions
 
+// Visibility
+PUBLIC_VISIBILITY : "public"
+PRIVATE_VISIBILITY : "private"
+NESTED_VISIBILITY : "nested"
+function_visibility : PUBLIC_VISIBILITY | PRIVATE_VISIBILITY | NESTED_VISIBILITY
+
 // Arguments
 named_argument : ssa_id ":" type attribute_dict?
 argument_list : (named_argument ("," named_argument)*) | (type attribute_dict? ("," type attribute_dict?)*)
@@ -201,7 +207,7 @@ module_body : "{" (function | module | block)* "}"
 
 // Definition
 module : "module" symbol_ref_id? ("attributes" attribute_dict)? module_body trailing_location?
-function : "func" function_signature ("attributes" attribute_dict)? function_body? trailing_location?
+function : "func" function_visibility? function_signature ("attributes" attribute_dict)? function_body? trailing_location?
 
 // ----------------------------------------------------------------------
 // (semi-)affine expressions, maps, and integer sets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lark-parser==0.7.8
-parse==1.14.0
+lark-parser>=0.7.8
+parse>=1.14.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fp:
 
 setup(
     name='pymlir',
-    version='0.3',
+    version='0.3.1',
     url='https://github.com/spcl/pymlir',
     author='SPCL @ ETH Zurich',
     author_email='talbn@inf.ethz.ch',


### PR DESCRIPTION
`astNodes.Function` now contains a `.visibility` attribute which will be either "public", "private", or "nested"

This can be used by the jit engine to filter out non-public functions.