### PR TITLE
"tensor.extract" to handle 0-dimensional inputs ; add support for "affine_map<(i,j,k) -> ()>"

### DIFF
--- a/mlir/dialects/standard.py
+++ b/mlir/dialects/standard.py
@@ -45,7 +45,7 @@ class DmaWaitOperation(DialectOp):
 class ExtractElementOperation(DialectOp): # TODO does this still exist in the latest std dialect?
     _syntax_ = 'extract_element {arg.ssa_use} [ {index.ssa_use_list} ] : {type.type}'
 class TensorExtractOperation(DialectOp): # TODO move this to its own dialect file
-    _syntax_ = 'tensor.extract {arg.ssa_use} [ {index.ssa_use_list} ] : {type.type}'
+    _syntax_ = 'tensor.extract {arg.ssa_use} [ {index.ssa_use_list_optional} ] : {type.type}'
 class LoadOperation(DialectOp):
     _syntax_ = [
         'load {arg.ssa_use} [ {index.ssa_use_list} ] : {type.memref_type}',

--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -51,6 +51,7 @@ ssa_id_list : ssa_id ("," ssa_id)*
 // Uses of an SSA value, e.g., in an operand list to an operation.
 ssa_use : ssa_id | constant_literal
 ssa_use_list : ssa_use ("," ssa_use)*
+ssa_use_list_optional : [ssa_use_list] // TODO can this be used in more places?
 
 // ----------------------------------------------------------------------
 // Types
@@ -251,7 +252,7 @@ semi_affine_expr : "(" semi_affine_expr ")"                        -> semi_affin
                    | "(" semi_affine_expr ")" -> semi_affine_parens
 
 multi_dim_affine_expr_no_parens : affine_expr ("," affine_expr)*
-multi_dim_affine_expr : "(" multi_dim_affine_expr_no_parens ")"
+multi_dim_affine_expr : "(" [multi_dim_affine_expr_no_parens] ")"
 multi_dim_semi_affine_expr : "(" semi_affine_expr ("," semi_affine_expr)* ")"
 affine_constraint : affine_expr ">=" "0"    -> affine_constraint_ge
                   | affine_expr "==" "0"    -> affine_constraint_eq


### PR DESCRIPTION

Previously, PyMLIR couldn't parse the following:
```
    %answer = tensor.extract %reduction[] : tensor<f32>
```

The empty square brackets weren't being parsed.

This is valid given the example code found at https://github.com/llvm/llvm-project/blob/e2310704d890ad252aeb1ca28b4b84d29514b1d1/mlir/test/Dialect/Standard/canonicalize.mlir#L276 .

This is now supported.

Also, PyMLIR couldn't parse traits like this (in particular see `affine_map<(i,j,k) -> ()>`):
```
    #trait_sum_reduction = {
      indexing_maps = [
        affine_map<(i,j,k) -> (i,j,k)>,  // A
        affine_map<(i,j,k) -> ()>        // x (scalar out)
      ],
      sparse = [
        [ "S", "S", "S" ],  // A
        [ ]                 // x
      ],
      iterator_types = ["reduction", "reduction", "reduction"],
      doc = "x += SUM_ijk A(i,j,k)"
    }
```

The empty parentheses weren't being parsed. 

This is valid given the example code found at https://github.com/llvm/llvm-project/blob/e2310704d890ad252aeb1ca28b4b84d29514b1d1/mlir/test/Dialect/Linalg/sparse_3d.mlir#L1287 .

Such cases are now supported.