### PR TITLE
Improvements for index_type

### DIFF
--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -65,7 +65,7 @@ complex_type : "complex" "<" type ">"
 tuple_type : "tuple" "<" (type ( "," type)*) ">"
 
 // Vector types
-vector_element_type : float_type | integer_type
+vector_element_type : float_type | integer_type | index_type
 vector_type : "vector" "<" static_dimension_list vector_element_type ">"
 
 // Tensor type


### PR DESCRIPTION
Allow `memref<?xindex>`. This is needed to code generated by sparsification.