### PR TITLE
Add missing "#" to output of mlir.astnodes.SparseTensorEncoding.dump

### DIFF
--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -477,7 +477,7 @@ class SparseTensorEncoding(Node):
             contents.append(f'dimOrdering = {self.dim_ordering.dump()}')
         contents.append(f'pointerBitWidth = {self.pointer_bit_width}')
         contents.append(f'indexBitWidth = {self.index_bit_width}')
-        result = f'sparse_tensor.encoding<{{ {",".join(contents)} }}>'
+        result = f'#sparse_tensor.encoding<{{ {",".join(contents)} }}>'
         return result
 
     @property


### PR DESCRIPTION
This is the old behavior:
```
    >>> import mlir
    >>> s = 'func private @func_0() -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = ["dense", "compressed"],dimOrdering = affine_map<(d0, d1) -> (d0, d1)>,pointerBitWidth = 64,indexBitWidth = 64 }>>'
    >>> print(mlir.parse_string(s).dump())
    module {
      func @func_0() -> tensor<?x?xf64, sparse_tensor.encoding<{ dimLevelType = ["dense", "compressed"],dimOrdering = affine_map<(d0, d1) -> (d0, d1)>,pointerBitWidth = 64,indexBitWidth = 64 }>> {
      }
    }
    >>>
```
Note that "sparse_tensor.encoding" is missing a `#` preceding it. This commit adds the `#` to the output.